### PR TITLE
Make mergesort.c 70% smaller in lines of code

### DIFF
--- a/mergesort.c
+++ b/mergesort.c
@@ -1,60 +1,18 @@
-// let's code mergesort in c, can you do?
 #include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
 
-void my_mergesort(int *arr, int len) {
-  //printf("%p %d\n", arr, len);
-  if (len == 1) { return; }
-  if (len == 2) {
-    if (arr[0] > arr[1]) {
-      int t = arr[1];
-      arr[1] = arr[0];
-      arr[0] = t;
-    }
-  }
-
-  int p = len/2;
-  int *arr1 = arr;
-  int *arr2 = arr+p;
-
-  my_mergesort(arr1, p);
-  my_mergesort(arr2, len-p);
-
-  int *t = malloc(sizeof(int)*len);
-  int *rt = t;
-  while (1) {
-    if (arr1 < arr+p && arr2 < arr+len) {
-      if (*arr1 <= *arr2) {
-        *t = *arr1;
-        arr1++;
-      } else {
-        *t = *arr2;
-        arr2++;
-      }
-    } else if(arr1 < arr+p) {
-      *t = *arr1;
-      arr1++;
-    } else if(arr2 < arr+len) {
-      *t = *arr2;
-      arr2++;
-    } else {
-      break;
-    }
-    t++;
-  }
-
-  memcpy(arr, rt, sizeof(int)*len);
-  free(rt);
+int* merge(int *a, int *b, int s) {
+	int *A=a+(s/2), *B=b+(s-s/2), v[s], *V=v+s, *i=v;
+	while (i<V) *i++ = (*a <= *b && a!=A || b==B) ? *a++ : *b++;
+	while (s--) *--b = *--i; // copy in reverse to original array
+	return b;
 }
 
-int main() {
-  int a[] = {5,9,1,3,4,6,6,3,2};
-  int len = sizeof(a)/sizeof(int);
-  my_mergesort(a, sizeof(a)/sizeof(int));
-  for (int i = 0; i < len; i++) {
-    printf("%d ", a[i]);
-  }
-  printf("\n");
+int* mergesort(int *a, int s) {
+	if (s == 1) return a;
+	return merge(mergesort(a, s/2), mergesort(a+s/2, s-s/2), s);
 }
 
+void main() {
+	int a[] = {5,9,1,3,4,6,6,3,2}; mergesort(a, 10);
+	int i=0; while (i < 9) printf("%d ", a[i++]); printf("\n");
+}


### PR DESCRIPTION
Before the change it was 31st. Now it is 4th:

```
 1  2 mergesort.ijs
 2  7 mergesort.coffee
 3  15 mergesort.ss
 4  18 mergesort.c
 5  19 mergesort.hs
 6  22 mergesort.fsx
 7  23 mergesort.exs
 8  23 mergesort.ml
 9  24 mergesort.tcl
10  26 mergesort.rb
11  27 mergesort.r
12  28 mergesort.pl
13  28 mergesort.ts
14  32 mergesort.dats
15  32 mergesort.pro
16  34 mergesort.lua
17  36 mergesort.py
18  39 mergesort.nim
19  39 mergesort.scala
20  41 mergesort.go
21  41 mergesort.java
22  43 mergesort.jl
23  43 mergesort.kt
24  43 mergesort.php
25  45 mergesort.b
26  47 mergesort.cpp
27  49 mergesort.d
28  49 mergesort.js
29  49 mergesort.swift
30  53 mergesort.rs
31  56 mergesort.sh
32  61 mergesort.dart
33  66 mergesort.m
34  74 mergesort.adb
35  74 mergesort.v
36  82 mergesort.cs
```